### PR TITLE
feat(ci): add automation workflows from gist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,95 @@
+name: Auto Assign Owner
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  check-and-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check collaborator count and assign owner
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Get collaborators with push or admin access
+            const { data: collaborators } = await github.rest.repos.listCollaborators({
+              owner,
+              repo,
+              permission: 'push'
+            });
+
+            // Filter to only users with push or admin (not just read)
+            const pushCollaborators = collaborators.filter(c =>
+              c.permissions?.push || c.permissions?.admin
+            );
+
+            console.log(`Found ${pushCollaborators.length} collaborators with push access`);
+
+            // Only auto-assign if there's 1 or fewer collaborators with push access
+            if (pushCollaborators.length > 1) {
+              console.log('Multiple collaborators found, skipping auto-assign');
+              return;
+            }
+
+            // Determine the assignee (repo owner)
+            const assignee = owner;
+
+            if (context.eventName === 'issues') {
+              const issue = context.payload.issue;
+
+              // Skip if already assigned
+              if (issue.assignees && issue.assignees.length > 0) {
+                console.log('Issue already has assignees, skipping');
+                return;
+              }
+
+              // Skip if author is a bot
+              if (issue.user.type === 'Bot') {
+                console.log('Issue author is a bot, skipping');
+                return;
+              }
+
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees: [assignee]
+              });
+
+              console.log(`Assigned issue #${issue.number} to ${assignee}`);
+
+            } else if (context.eventName === 'pull_request_target') {
+              const pr = context.payload.pull_request;
+
+              // Skip if already assigned
+              if (pr.assignees && pr.assignees.length > 0) {
+                console.log('PR already has assignees, skipping');
+                return;
+              }
+
+              // Skip if author is a bot
+              if (pr.user.type === 'Bot') {
+                console.log('PR author is a bot, skipping');
+                return;
+              }
+
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pr.number,
+                assignees: [assignee]
+              });
+
+              console.log(`Assigned PR #${pr.number} to ${assignee}`);
+            }

--- a/.github/workflows/dependabot-issue.yml
+++ b/.github/workflows/dependabot-issue.yml
@@ -1,0 +1,63 @@
+name: Create Issue for Dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  create-tracking-issue:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tracking issue for Dependabot PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Extract version info from PR title
+            // Typical format: "Bump actions/checkout from 3 to 4"
+            const title = pr.title;
+
+            const issueTitle = `deps: ${title}`;
+            const issueBody = `## Dependabot Update
+
+            ${pr.body || 'Automated dependency update.'}
+
+            ## Pull Request
+
+            - PR: #${pr.number}
+            - Author: @${pr.user.login}
+            - URL: ${pr.html_url}
+
+            ---
+            This issue was automatically created to track the Dependabot update.
+            `;
+
+            const { data: issue } = await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              labels: ['dependencies', 'github-actions']
+            });
+
+            console.log(`Created tracking issue #${issue.number} for PR #${pr.number}`);
+
+            // Update PR body to reference the issue
+            const updatedBody = `${pr.body || ''}\n\n---\nCloses #${issue.number}`;
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pr.number,
+              body: updatedBody
+            });
+
+            console.log(`Updated PR #${pr.number} to close issue #${issue.number}`);

--- a/.github/workflows/dependabot-issue.yml
+++ b/.github/workflows/dependabot-issue.yml
@@ -50,14 +50,5 @@ jobs:
 
             console.log(`Created tracking issue #${issue.number} for PR #${pr.number}`);
 
-            // Update PR body to reference the issue
-            const updatedBody = `${pr.body || ''}\n\n---\nCloses #${issue.number}`;
-
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number: pr.number,
-              body: updatedBody
-            });
-
-            console.log(`Updated PR #${pr.number} to close issue #${issue.number}`);
+            // Note: We don't update the PR body because Dependabot PRs have
+            // restricted permissions. The issue references the PR instead.


### PR DESCRIPTION
## Summary

Add automation workflows from `templates.hbs(github/workflows/automation)` gist.

## Files Added

| File | Purpose |
|------|---------|
| `.github/workflows/auto-assign.yml` | Auto-assigns owner to issues/PRs when single maintainer |
| `.github/workflows/dependabot-issue.yml` | Creates tracking issues for Dependabot PRs |
| `.github/dependabot.yml` | Weekly GitHub Actions version updates |

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)